### PR TITLE
WIP: Display everything in a frame in the top window

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -197,18 +197,20 @@ function display{A<:AbstractArray}(img::A; proplist...)
     end
     # Create the window and the canvas for displaying the image
     win = Toplevel(get(props, "name", "ImageView"), ww, whfull, false)
-    c = Canvas(win, ww, wh)
+    f = Frame(win, padding = [10, 10, 10, 10], relief="groove")
+    pack(f, expand = true, fill = "both")
+    c = Canvas(f, ww, wh)
     imgc.c = c
     # Place the canvas and set its resize properties
     grid(c, 1, 1, sticky="nsew")        # fill the edges of its cell on all 4 sides
-    grid_rowconfigure(win, 1, weight=1) # scale this cell when the window resizes
-    grid_columnconfigure(win, 1, weight=1)
+    grid_rowconfigure(f, 1, weight=1) # scale this cell when the window resizes
+    grid_columnconfigure(f, 1, weight=1)
     # If necessary, create the navigation controls
     if havecontrols
         ctrls = NavigationControls()
         state = NavigationState(zmax, tmax)
         showframe = state -> reslice(imgc, img2, state)
-        fctrls = Frame(win)
+        fctrls = Frame(f)
         grid(fctrls, 2, 1, sticky="ew")  # place the controls below the image
         init_navigation!(fctrls, ctrls, state, showframe)
         if zmax > 1
@@ -226,7 +228,7 @@ function display{A<:AbstractArray}(img::A; proplist...)
         bindwheel(c, "Alt-Control", (path,delta)->reslicez(imgc,img2,ctrls,state,int(delta)))
     end
     # Set up the rendering
-    set_visible(win, true)
+    set_visible(win, true) # TODO: f for this one too?
     ctx = getgc(c)  # force initialization of canvas
     allocate_surface!(imgc, w, h)
     # Set up the drawing callbacks
@@ -235,10 +237,10 @@ function display{A<:AbstractArray}(img::A; proplist...)
     c.mouse.button1press = (c, x, y) -> rubberband_start(c, x, y, (c, bb) -> zoombb(imgc, img2, bb))
     bind(c, "<Double-Button-1>", (path,x,y)->zoom_reset(imgc, img2))
     # Bind mousewheel events to zoom
-    bindwheel(c, "Control", (path,delta,x,y)->zoomwheel(imgc,img2,int(delta),int(x),int(y)), "%x %y")
+#    bindwheel(c, "Control", (path,delta,x,y)->zoomwheel(imgc,img2,int(delta),int(x),int(y)), "%x %y")
     # Bind mousewheel events to pan
-    bindwheel(c, "", (path,delta)->panvert(imgc,img2,int(delta)))
-    bindwheel(c, "Shift", (path,delta)->panhorz(imgc,img2,int(delta)))
+#    bindwheel(c, "", (path,delta)->panvert(imgc,img2,int(delta)))
+#    bindwheel(c, "Shift", (path,delta)->panhorz(imgc,img2,int(delta)))
     # render the initial state
     rerender(imgc, img2)
     resize(imgc, img2)


### PR DESCRIPTION
By placing padding around this frame, we get around the problem of no
window borders on OS X.  Without this, mouse clicks/drags are
interpreted as a rubberband event as well as a resize event.  That 
confusion leads to fun resize behavior, where clicking on the window border
zooms in on a couple dozen pixels.

I'm guessing there is a better way to do this.

One side effect of this change is that it cuts down on the BoundsErrors (#1).
Doesn't eliminate them, however.
