### PR TITLE
Renaming: display->view, delete_annotation! -> delete!

### DIFF
--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -8,6 +8,9 @@ using Tk
 using Cairo
 using Images
 
+import Base: parent, show, delete!, empty!
+import Base.Graphics: width, height, fill, set_coords
+import Gtk: toplevel, draw
 # include("config.jl")
 # include("external.jl")
 include("rubberband.jl")
@@ -23,14 +26,19 @@ export # types
     annotate!,
     canvas,
     canvasgrid,
-    delete_annotation!,
     delete_annotations!,
     destroy,
-    display,
 #     ftshow,
 #     imshow,
     parent,
     scalebar,
-    toplevel
+    toplevel,
+    view
+
+@deprecate delete_annotations! empty!
+@deprecate delete_annotation! delete!
+@deprecate display(c::Canvas, img::AbstractArray; proplist...) view(c, img; proplist...)
+@deprecate display(imgc::ImageCanvas, img::AbstractArray; proplist...) view(imgc, img; proplist...)
+@deprecate display(img::AbstractArray; proplist...) view(img; proplist...)
 
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -220,7 +220,7 @@ yrange(img2::ImageSlice2d) = (ymin(img2), ymax(img2))
 #   name: a string giving the window name
 #   background, perimeter: colors
 
-function display{A<:AbstractArray}(img::A; proplist...)
+function view{A<:AbstractArray}(img::A; proplist...)
     # Convert keyword list to dictionary
     props = Dict{Symbol,Any}()
     sizehint(props, length(proplist))
@@ -312,7 +312,7 @@ function display{A<:AbstractArray}(img::A; proplist...)
 end
 
 # Display a new image in an old ImageCanvas, preserving properties
-function display{A<:AbstractArray}(imgc::ImageCanvas, img::A; proplist...)
+function view{A<:AbstractArray}(imgc::ImageCanvas, img::A; proplist...)
     # Convert keyword list to dictionary
     props = Dict{Symbol,Any}()
     sizehint(props, length(proplist))
@@ -332,7 +332,7 @@ function display{A<:AbstractArray}(imgc::ImageCanvas, img::A; proplist...)
 end
 
 # Display an image in a Canvas. Do not create controls.
-function display{A<:AbstractArray}(c::Canvas, img::A; proplist...)
+function view{A<:AbstractArray}(c::Canvas, img::A; proplist...)
     # Convert keyword list to dictionary
     props = Dict{Symbol,Any}()
     sizehint(props, length(proplist))
@@ -382,6 +382,11 @@ function annotate!(imgc::ImageCanvas, img2::ImageSlice2d, ann; anchored::Bool=tr
     len
 end
 
+immutable AnnotationHandle{T}
+    ann::T
+    hash::Uint
+end
+
 function annotate_nodraw!(imgc::ImageCanvas, img2::ImageSlice2d, ann; anchored::Bool=true)
     local newann
     if anchored
@@ -391,7 +396,7 @@ function annotate_nodraw!(imgc::ImageCanvas, img2::ImageSlice2d, ann; anchored::
     end
     h = hash(newann)
     imgc.annotations[h] = newann
-    h
+    AnnotationHandle(newann, h)
 end
 
 function validate_annotations!(imgc::ImageCanvas)
@@ -401,12 +406,12 @@ function validate_annotations!(imgc::ImageCanvas)
     end
 end    
 
-function delete_annotation!(imgc::ImageCanvas, h::Uint)
-    delete!(imgc.annotations, h)
+function delete!(imgc::ImageCanvas, h::AnnotationHandle)
+    delete!(imgc.annotations, h.hash)
     redraw(imgc)
 end
 
-function delete_annotations!(imgc::ImageCanvas)
+function empty!(imgc::ImageCanvas)
     empty!(imgc.annotations)
     redraw(imgc)
 end

--- a/test/annotations.jl
+++ b/test/annotations.jl
@@ -4,11 +4,11 @@ z = ones(10,50);
 y = 8; x = 2;
 z[y,x] = 0
 zimg = convert(Image, z)
-imgc, img2 = ImageView.display(zimg,pixelspacing=[1,1]);
+imgc, img2 = ImageView.view(zimg,pixelspacing=[1,1]);
 Tk.set_size(ImageView.toplevel(imgc), 200, 200)
 idx = ImageView.annotate!(imgc, img2, ImageView.AnnotationText(x, y, "x", color=RGB(0,0,1), fontsize=3))
 idx2 = ImageView.annotate!(imgc, img2, ImageView.AnnotationPoint(x+10, y, shape='.', size=4, color=RGB(1,0,0)))
 idx3 = ImageView.annotate!(imgc, img2, ImageView.AnnotationPoint(x+20, y-6, shape='.', size=1, color=RGB(1,0,0), linecolor=RGB(0,0,0), scale=true))
 idx4 = ImageView.annotate!(imgc, img2, ImageView.AnnotationLine(x+10, y, x+20, y-6, linewidth=2, color=RGB(0,1,0)))
 # Also test the following:
-# ImageView.delete_annotation!(imgc, idx)
+# ImageView.delete!(imgc, idx)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
 include("tile.jl")
 include("annotations.jl")
 include("test4d.jl")
-ImageView.display(img)
+ImageView.view(img)

--- a/test/tile.jl
+++ b/test/tile.jl
@@ -3,7 +3,7 @@ using Color
 using TestImages
 
 c = ImageView.canvasgrid(2,2)
-ImageView.display(c[1,1], testimage("lighthouse"), pixelspacing=[1,1])
-ImageView.display(c[1,2], testimage("mountainstream", RGB), pixelspacing=[1,1])
-ImageView.display(c[2,1], testimage("moonsurface"), pixelspacing=[1,1])
-ImageView.display(c[2,2], testimage("mandrill"), pixelspacing=[1,1])
+ImageView.view(c[1,1], testimage("lighthouse"), pixelspacing=[1,1])
+ImageView.view(c[1,2], testimage("mountainstream", RGB), pixelspacing=[1,1])
+ImageView.view(c[2,1], testimage("moonsurface"), pixelspacing=[1,1])
+ImageView.view(c[2,2], testimage("mandrill"), pixelspacing=[1,1])


### PR DESCRIPTION
This is a bit scary, but I've been thinking about it for a long time and decided before JuliaCon that it was time to do this. Basically the problem is that `using ImageView` has been resulting in a conflict with the `Base.display` function. So this renames `display` to `view`. It also cleans up working with annotations: they used to be returned as a `Uint`, but this wraps them in a type so that functions like `delete!` can be used.
