### PR TITLE
Add pixel value under cursor to statusbar.

### DIFF
--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -1,0 +1,2 @@
+imgdy = Uint8[y for y=0x00:0xff, x=0:100]
+imgdx = Uint8[x for y=1:100, x=0x00:0xff]


### PR DESCRIPTION
Also fixes corner-case of (0,0) coordinates.

I'm pretty sure the way I extract the pixel value is not the best one. I played around with the `ImageSlice2d` but failed getting it from there (The `imslice` member is only the currently displayed subarray.)

The `vec(val)` part is there for m-n-3 images, where `val` would be a column vector, and the `length(val)==1` guard for grayscale images. I couldn't test for 3D/4D images since I don't have any.
