### PR TITLE
Fix handling of clim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
             - xauth
             - libgtk-3-0
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/src/slicing.jl
+++ b/src/slicing.jl
@@ -5,6 +5,14 @@ struct SliceData{transpose,N,Axs}
     axs::Axs
 end
 
+function Base.show(io::IO, sd::SliceData{transpose,N}) where {transpose,N}
+    println(io, "SliceData{transpose=$transpose}:")
+    for i = 1:N
+        println(io, "  ", axisname(sd.axs[i]), ": ", value(sd.signals[i]))
+    end
+end
+axisname(ax::Axis) = axisnames(ax)[1]
+
 """
     SliceData{transpose::Bool}(signals::NTuple{N,Signal{Int}}, axes::NTuple{N,Axes})
 

--- a/test/test4d.jl
+++ b/test/test4d.jl
@@ -5,7 +5,7 @@ using AxisArrays, Colors
 sz = [201, 301, 31]
 center = [(s+1)>>1 for s in sz]  # ceil(Int, sz/2)
 C3 = Bool[(i-center[1])^2+(j-center[2])^2 <= k^2 for i = 1:sz[1], j = 1:sz[2], k = sz[3]:-1:1]
-cmap1 = round(UInt32, linspace(0,255,60))
+cmap1 = round.(UInt32, linspace(0,255,60))
 cmap = Array{UInt32}(length(cmap1))
 for i = 1:length(cmap)
     cmap[i] = cmap1[i]<<16 + cmap1[end-i+1]<<8 + cmap1[i]


### PR DESCRIPTION
The documentation suggested that one could pass in a `CLim` object, but it didn't work unless it was really a `Signal{CLim}`, which is too finicky for users. This allows the `CLim`.