### PR TITLE
Restrict current release to Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
             - libgtk-3-0
 julia:
     - 0.6
-    - nightly
 notifications:
   email: false
 script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.6 0.7
 Images 0.6.0
 GtkReactive 0.4.2
 FixedPointNumbers 0.3


### PR DESCRIPTION
I know this will be requested before tagging another release that doesn't support Julia 0.7, so let's just do it ahead of time.