### PR TITLE
Update histogram whenever `enabled` changes state (fixes #168)

### DIFF
--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -487,7 +487,7 @@ default_axes(img::AxisArray) = axisnames(img)[[1,2]]
 # default_slices(img) = ntuple(d->PlayerInfo(Signal(1), axes(img, d+2)), ndims(img)-2)
 
 function histsignals(enabled::Signal, defaultimg, img::Signal, clim::Signal{CLim{T}}) where {T<:GrayLike}
-    return [map(filterwhen(enabled, defaultimg, img); name="histsig") do image
+    return [map(filterwhen(enabled, defaultimg, img), enabled; name="histsig") do image, _  # `enabled` fixes issue #168
         cl = value(clim)
         smin = float(nanz(min(minfinite(image), cl.min)))
         smax = float(nanz(max(maxfinite(image), cl.max)))

--- a/test/contrast.jl
+++ b/test/contrast.jl
@@ -22,5 +22,12 @@ using Test
             @test isa(ret, Dict)
             Gtk.destroy(ret["window"])
         end
+        # issue #168
+        h = value(value(histsig)[1])
+        fill!(h.weights, 0)
+        push!(enabled, false)
+        yield()
+        h = value(value(histsig)[1])
+        @test sum(h.weights) > 0
     end
 end


### PR DESCRIPTION
We make `enabled` an unused dependency of the histogram-calculating code, thus ensuring it updates.