### PR TITLE
Switch to TAGBOT key for CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -28,5 +28,5 @@ jobs:
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          COMPATHELPER_PRIV: ${{ secrets.TAGBOT }}
           # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}


### PR DESCRIPTION
The CompatHelper script gives this interesting message:
```
[ Info: This doesn't look like a raw SSH private key. I will assume that it is a Base64-encoded SSH private key. I will now try to Base64-decode it.
[ Info: This was a Base64-encoded SSH private key. I Base64-decoded it, and now I have the raw SSH private key.
```
but then various "permission denied" errors follow.
This switches to the TAGBOT key like Images.jl.