### PR TITLE
Make 1.6LTS the earliest supported version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,16 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ['1.0', '1', 'nightly']
+        version: ['1.6', '1', 'nightly']
         arch: [x64]
         include:
           - os: ubuntu-latest
             prefix: xvfb-run
-        exclude:
-          - os: macOS-latest      # Cairo fails to build properly on this combination
-            version: '1.0'
-          - os: windows-latest    # Gtk fails to build properly on this combination
-            version: '1.0'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ ImageCore = "0.9"
 ImageMetadata = "0.9"
 RoundingIntegers = "0.2, 1"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
-julia = "1"
+julia = "1.6"
 
 [extras]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"


### PR DESCRIPTION
Given that Julia 1.0 can't build Gtk anymore on any platform, it's time for a breaking release. We might as well jump to the next LTS.