### PR TITLE
Support very large images with `restrict`

### DIFF
--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -113,7 +113,7 @@ function imshow!(canvas::GtkObservables.Canvas{UserUnit},
                  zr::Observable{ZoomRegion{T}},
                  annotations::Annotations=annotations()) where T<:RInteger
     draw(canvas, imgsig, annotations) do cnvs, image, anns
-        copy!(cnvs, image)
+        copy_with_restrict!(cnvs, image)
         set_coordinates(cnvs, zr[])
         draw_annotations(cnvs, anns)
     end
@@ -125,7 +125,7 @@ function imshow!(frame::Frame,
                  zr::Observable{ZoomRegion{T}},
                  annotations::Annotations=annotations()) where T<:RInteger
     draw(canvas, imgsig, annotations) do cnvs, image, anns
-        copy!(cnvs, image)
+        copy_with_restrict!(cnvs, image)
         set_coordinates(cnvs, zr[])
         set_aspect!(frame, image)
         draw_annotations(cnvs, anns)
@@ -139,7 +139,7 @@ function imshow!(canvas::GtkObservables.Canvas,
                  imgsig::Observable,
                  annotations::Annotations=annotations())
     draw(canvas, imgsig, annotations) do cnvs, image, anns
-        copy!(cnvs, image)
+        copy_with_restrict!(cnvs, image)
         set_coordinates(cnvs, axes(image))
         draw_annotations(cnvs, anns)
     end
@@ -150,11 +150,20 @@ function imshow!(canvas::GtkObservables.Canvas,
                  img::AbstractMatrix,
                  annotations::Annotations=annotations())
     draw(canvas, annotations) do cnvs, anns
-        copy!(cnvs, img)
+        copy_with_restrict!(cnvs, img)
         set_coordinates(cnvs, axes(img))
         draw_annotations(cnvs, anns)
     end
     nothing
+end
+
+function copy_with_restrict!(cnvs, img::AbstractMatrix)
+    imgsz = size(img)
+    while (imgsz[1] > 2*Graphics.height(cnvs) && imgsz[2] > 2*Graphics.width(cnvs))
+        img = restrict(img)
+        imgsz = size(img)
+    end
+    copy!(cnvs, img)
 end
 
 """

--- a/test/newtests.jl
+++ b/test/newtests.jl
@@ -81,6 +81,13 @@ end
     w, h = size(win)
     ws, hs = screen_size(win)
     !Sys.iswindows() && @test w <= ws && h <= hs
+
+    # a very large image
+    img = rand(N0f8, 10000, 15000)
+    hbig = imshow_now(img, name="VeryBig"; canvassize=(500,500))
+    cvs = hbig["gui"]["canvas"];
+    @test Graphics.height(getgc(cvs)) <= 500
+    @test Graphics.width(getgc(cvs)) <= 500
 end
 
 @testset "imshow!" begin

--- a/test/newtests.jl
+++ b/test/newtests.jl
@@ -20,6 +20,7 @@ end
     @test get_gtk_property(frame, :ratio, Float32) == 1.0
     zr[] = (1:20, 9:10)
     @test zr[].currentview.x == 9..10
+    sleep(0.1)  # allow the Gtk event loop to run
     if Sys.islinux()
         @test_broken get_gtk_property(frame, :ratio, Float32) ≈ 0.1
     else
@@ -85,6 +86,7 @@ end
     # a very large image
     img = rand(N0f8, 10000, 15000)
     hbig = imshow_now(img, name="VeryBig"; canvassize=(500,500))
+    sleep(0.1)  # some extra sleep for this big image
     cvs = hbig["gui"]["canvas"];
     @test Graphics.height(getgc(cvs)) <= 500
     @test Graphics.width(getgc(cvs)) <= 500

--- a/test/newtests.jl
+++ b/test/newtests.jl
@@ -21,11 +21,7 @@ end
     zr[] = (1:20, 9:10)
     @test zr[].currentview.x == 9..10
     sleep(0.1)  # allow the Gtk event loop to run
-    if Sys.islinux()
-        @test_broken get_gtk_property(frame, :ratio, Float32) ≈ 0.1
-    else
-        @test get_gtk_property(frame, :ratio, Float32) ≈ 0.1
-    end
+    @test get_gtk_property(frame, :ratio, Float32) ≈ 0.1
     zr[] = (9:10, 1:20)
     Gtk.showall(win)
     sleep(0.1)


### PR DESCRIPTION
xref https://github.com/JuliaAstro/AstroImages.jl/issues/10 and
https://discourse.julialang.org/t/plotting-image-data-in-julia-is-much-slower-than-matlab/79660