### PR TITLE
Make it easier to identify mapping errors

### DIFF
--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -257,6 +257,13 @@ function imshow(frame::Gtk.GtkFrame, canvas::GtkObservables.Canvas,
     set_aspect!(frame, imgsig[])
     imgc = prep_contrast(canvas, imgsig, clim)
     GtkObservables.gc_preserve(frame, imgc)
+    # If there is an error in one of the functions being mapped elementwise, we often don't
+    # discover it until it triggers an error inside `Gtk.draw`. Check for problems here so
+    # such errors become easier to debug.
+    if eltype(imgc[]) === Union{}
+        eltype(imgsig[]) === Union{} && error("got Union{} eltype in creating slice")
+        error("got Union{} eltype in preparing the constrast")
+    end
 
     roidict = imshow(frame, canvas, imgc, zr, anns)
     roidict["slicedata"] = sd

--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -260,9 +260,9 @@ function imshow(frame::Gtk.GtkFrame, canvas::GtkObservables.Canvas,
     # If there is an error in one of the functions being mapped elementwise, we often don't
     # discover it until it triggers an error inside `Gtk.draw`. Check for problems here so
     # such errors become easier to debug.
-    if eltype(imgc[]) === Union{}
-        eltype(imgsig[]) === Union{} && error("got Union{} eltype in creating slice")
-        error("got Union{} eltype in preparing the constrast")
+    if !supported_eltype(imgc[])
+        !supported_eltype(imgsig[]) && error("got unsupported eltype $(eltype(imgsig[])) in creating slice")
+        error("got unsupported eltype $(eltype(imgc[])) in preparing the constrast")
     end
 
     roidict = imshow(frame, canvas, imgc, zr, anns)
@@ -741,6 +741,11 @@ _mappedarray(f, img::ImageMeta) = shareproperties(img, _mappedarray(f, data(img)
 wrap_signal(x) = Observable(x)
 wrap_signal(x::Observable) = x
 wrap_signal(::Nothing) = nothing
+
+function supported_eltype(@nospecialize(img))
+    T = eltype(img)
+    return T <: Union{Number,Colorant} && T !== Union{}
+end
 
 include("link.jl")
 include("contrast_gui.jl")

--- a/test/newtests.jl
+++ b/test/newtests.jl
@@ -111,6 +111,24 @@ end
     @test parent(guidict["roi"]["image roi"][]) == [4 3; 2 1]
 end
 
+@testset "Mapping errors" begin
+    # Create a colortype with missing methods
+    struct OneChannelColor{T} <: Color{T,1}
+        val1::T
+    end
+    img = [OneChannelColor(0) OneChannelColor(1);
+           OneChannelColor(2) OneChannelColor(3);
+    ]
+    @test_throws ErrorException("got unsupported eltype Union{} in preparing the constrast") imshow(img, CLim(0, 1))
+
+    struct MyChar <: AbstractChar
+        c::Char
+    end
+    ImageView.prep_contrast(canvas, @nospecialize(img::Observable), clim::Observable{CLim{MyChar}}) = img
+    img = MyChar['a' 'b'; 'c' 'd']
+    @test_throws ErrorException("got unsupported eltype MyChar in creating slice") imshow(img, CLim{MyChar}('a', 'b'))
+end
+
 if Gtk.libgtk_version >= v"3.10"
     # These tests use the player widget
     @testset "Multidimensional" begin


### PR DESCRIPTION
Discovering errors during rendering is not ideal, because it's quite
hard to trace back to the original cause. This puts in a simple
check before rendering the suitably-scaled image.