### PR TITLE
Stop pirating `scaleminmax`

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -10,7 +10,7 @@ using AxisArrays: Axis
     @test cl[] === CLim{Float64}(0, 1)
 
     cmin = Gray(0.2)
-    cmax = RGB(0.8)
+    cmax = Gray(0.8)
     smm = ImageView.scalechannels(Gray{N0f8}, cmin, cmax)
     @test @inferred(smm(cmin)) == Gray(0)
     @test @inferred(smm(cmax)) == Gray(1)

--- a/test/core.jl
+++ b/test/core.jl
@@ -9,9 +9,16 @@ using AxisArrays: Axis
     cl[] = CLim(0, 1)
     @test cl[] === CLim{Float64}(0, 1)
 
+    cmin = Gray(0.2)
+    cmax = RGB(0.8)
+    smm = ImageView.scalechannels(Gray{N0f8}, cmin, cmax)
+    @test @inferred(smm(cmin)) == Gray(0)
+    @test @inferred(smm(cmax)) == Gray(1)
+    @test @inferred(smm((cmin+1.00001*cmax)/2)) == Gray{N0f8}(0.5)
+
     cmin = RGB(0.2,0.4,0.1)
     cmax = RGB(1.0,0.8,0.95)
-    smm = scaleminmax(RGB{N0f8}, cmin, cmax)
+    smm = ImageView.scalechannels(RGB{N0f8}, cmin, cmax)
     @test @inferred(smm(cmin)) == RGB(0,0,0)
     @test @inferred(smm(cmax)) == RGB(1,1,1)
     @test @inferred(smm((cmin+1.00001*cmax)/2)) == RGB{N0f8}(0.5,0.5,0.5)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,8 +1,7 @@
 using GtkObservables, ImageCore, ImageView
 using ImageView: sliceinds
 using Test
-import AxisArrays
-using AxisArrays: Axis
+using AxisArrays: AxisArrays, Axis, AxisArray
 
 @testset "CLim" begin
     cl = Observable(CLim(0.0, 0.8))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ if !isdefined(@__MODULE__, :imshow_now)
     end
 end
 
+include("core.jl")
 include("simple.jl")
 include("contrast.jl")
 include("kwargs.jl")


### PR DESCRIPTION
`scaleminmax` is owned by ImageCore and the colors it operates
on are owned by ColorTypes. In contrast to both Colors and
ColorVectorspace, for which piracy is their raison d'etre,
this is not really a sanctioned case of piracy.

We could add these methods to ImageCore, but I think they'd be a
little dicey, so best to make them internal.