### PR TITLE
Switch to SnoopPrecompile for precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 MultiChannelColors = "d4071afc-4203-49ee-90bc-13ebeb18d604"
 RoundingIntegers = "d5f540fe-1c90-5db3-b776-2e2f362d9394"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
@@ -29,6 +30,7 @@ ImageCore = "0.9"
 ImageMetadata = "0.9"
 MultiChannelColors = "0.1.1"
 RoundingIntegers = "0.2, 1"
+SnoopPrecompile = "1"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.6"
 

--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -781,17 +781,8 @@ include("link.jl")
 include("contrast_gui.jl")
 include("annotations.jl")
 
-if ccall(:jl_generating_output, Cint, ()) == 1 && (!Sys.isunix() || haskey(ENV, "DISPLAY"))
-    # Partial workaround for https://github.com/JuliaLang/julia/issues/45050
-    if hasfield(Method, :constprop) && isdefined(@__MODULE__, Symbol("#imshow##kw"))
-        for m in methods(var"#imshow##kw".instance)
-            m.constprop = 0x02
-            for mb in methods(Base.bodyfunction(m))
-                mb.constprop = 0x02
-            end
-        end
-    end
-    # Precompile
+using SnoopPrecompile
+@precompile_all_calls begin
     for T in (N0f8, N0f16, Float32)
         for C in (Gray, RGB)
             img = rand(C{T}, 2, 2)


### PR DESCRIPTION
On my machine, on `master` with Julia 1.6:
```
julia> @time using ImageCore, ImageView
  3.133214 seconds (7.36 M allocations: 474.322 MiB, 9.91% gc time, 43.39% compilation time)

julia> @time @eval img = rand(RGB{N0f8}, 100, 120);
  0.156444 seconds (825.12 k allocations: 49.383 MiB, 11.35% gc time, 99.81% compilation time)

julia> @time @eval h = imshow(img);
  2.514401 seconds (8.79 M allocations: 520.388 MiB, 4.35% gc time, 4.57% compilation time)
```

With Julia nightly, on the master branch of ImageView it's somewhat better:
```
julia> @time using ImageCore, ImageView
  2.439186 seconds (6.09 M allocations: 382.197 MiB, 7.44% gc time, 14.67% compilation time)

julia> @time @eval img = rand(RGB{N0f8}, 100, 120);
  0.121767 seconds (260.59 k allocations: 17.305 MiB, 12.40% gc time, 168.10% compilation time)

julia> @time @eval h = imshow(img);
  0.792889 seconds (1.16 M allocations: 74.301 MiB, 1.84% gc time, 102.55% compilation time: 2% of which was recompilation)
```

But it's best with this PR:
```
julia> @time using ImageCore, ImageView
  2.585504 seconds (6.80 M allocations: 422.312 MiB, 9.54% gc time, 13.56% compilation time)

julia> @time @eval img = rand(RGB{N0f8}, 100, 120);
  0.000396 seconds (96 allocations: 40.219 KiB)

julia> @time @eval h = imshow(img);
  0.216154 seconds (5.63 k allocations: 362.281 KiB, 31.35% compilation time)
```

Almost 4x faster to show the first window.