### PR TITLE
`closeall` also handles contrast windows

### DIFF
--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -795,6 +795,7 @@ using SnoopPrecompile
         end
     end
     closeall()   # this is critical: you don't want to precompile with window_wrefs loaded with junk (dangling window pointers from closed session)
+    sleep(1)   # avoid a "waiting for IO to finish" warning on 1.10
 end
 
 end # module

--- a/src/contrast_gui.jl
+++ b/src/contrast_gui.jl
@@ -123,6 +123,10 @@ end
 
 function contrast_gui_layout(smin::Observable, smax::Observable, rng; wname="Contrast")
     win = Window(wname) |> (g = Grid())
+    window_wrefs[win] = nothing
+    signal_connect(win, :destroy) do w
+        delete!(window_wrefs, win)
+    end
     slmax = slider(rng; observable=smax)
     slmin = slider(rng; observable=smin)
     for sl in (slmax, slmin)


### PR DESCRIPTION
This caused a block in precompilation on 1.10 due to waiting for IO operations to complete., but it's also a nice usability enhancement.