### PR TITLE
Prevent an infinite loop in the contrast GUI

### DIFF
--- a/src/contrast_gui.jl
+++ b/src/contrast_gui.jl
@@ -98,9 +98,11 @@ function contrast_gui(enabled::Observable{Bool}, hist::Observable, clim::Observa
                 cmaxT = max(cmaxT, cmaxT+Δ)
             end
             mn, mx = minimum(rng), maximum(rng)
-            cmin, cmax = clamp(cminT, mn, mx), clamp(cmaxT, mn, mx)
-            cgui["slider_min"][] = (rng, cmin)
-            cgui["slider_max"][] = (rng, cmax)
+            cmin, cmax = T(clamp(cminT, mn, mx)), T(clamp(cmaxT, mn, mx))
+            if cmin != cgui["slider_min"][] || cmax != cgui["slider_max"][]
+                cgui["slider_min"][] = (rng, cmin)
+                cgui["slider_max"][] = (rng, cmax)
+            end
         end
         # Update the image contrast
         clim[] = CLim(cmin, cmax)


### PR DESCRIPTION
Convert new contrast limit values to the right type and only update if the new values are different from the old values.

Prevents a crash when the contrast bars cross.

Fixes #308

It would be ideal to add a test too, but I don't have time this morning.