### PR TITLE
Label in the bottom right corner showing the current view

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ['1.6', '1']
+        version: ['1']
         arch: [x64, x86]
         include:
           - os: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageView"
 uuid = "86fae568-95e7-573e-a6b2-d8a6b900c9ef"
 author = ["Tim Holy <tim.holy@gmail.com"]
-version = "0.12.6"
+version = "0.13.0"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
@@ -32,7 +32,8 @@ MultiChannelColors = "0.1.1"
 PrecompileTools = "1"
 RoundingIntegers = "0.2, 1"
 StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
-julia = "1.6"
+julia = "1.10"
+TestImages = "1.9"
 
 [extras]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"

--- a/README.md
+++ b/README.md
@@ -384,6 +384,6 @@ manually close it with `CTRL + C`.
 If you are opening more than one window you will need to create more
 than one `Condition` object, if you wish to wait until the last one is
 closed. See 
-(here)[https://juliagtk.github.io/Gtk4.jl/dev/howto/nonreplusage/] for
+[here](https://juliagtk.github.io/Gtk4.jl/dev/howto/nonreplusage/) for
 more information.
 


### PR DESCRIPTION
Label shows the current view (only when zoomed in). This is selectable, allowing users to cut and paste into an editor (or the REPL).

Also includes a microoptimization in the hover label setter and a minor fix to the README.

Finally, require Julia 1.10 and bump version.