### PR TITLE
FileIO extension for imshow()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,12 @@ StatsBase = "0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
 julia = "1.10"
 TestImages = "1.9"
 
+[weakdeps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+
+[extensions]
+ImageViewFileIOExt = "FileIO"
+
 [extras]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You should get a window with your image:
 ![photo](readme_images/photo1.jpg)
 
 You can use `imshow()` if you want to choose an image using a file
-dialog.
+dialog (requires [FileIO](https://github.com/JuliaIO/FileIO.jl)).
 
 Try resizing the image window by dragging one of its corners; you'll
 see that the aspect ratio of the image is preserved when you

--- a/ext/ImageViewFileIOExt.jl
+++ b/ext/ImageViewFileIOExt.jl
@@ -1,0 +1,12 @@
+module ImageViewFileIOExt
+
+using FileIO, ImageView, Gtk4
+
+"""
+    imshow()
+
+Choose an image to display via a file dialog.
+"""
+ImageView.imshow() = imshow(load(open_dialog("Pick an image to display")))
+
+end

--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -60,13 +60,6 @@ end
 const window_wrefs = WeakKeyDict{Gtk4.GtkWindowLeaf,Nothing}()
 
 """
-    imshow()
-
-Choose an image to display via a file dialog.
-"""
-imshow() = imshow(load(open_dialog("Pick an image to display")))
-
-"""
     imshow!(canvas, img) -> drawsignal
     imshow!(canvas, img::Observable, zr::Observable{ZoomRegion}) -> drawsignal
     imshow!(frame::Frame, canvas, img::Observable, zr::Observable{ZoomRegion}) -> drawsignal


### PR DESCRIPTION
When FileIO is present, `imshow()` will open an image using a dialog.

Fixes https://github.com/JuliaImages/ImageView.jl/issues/291.