### PR TITLE
fix tests

### DIFF
--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -564,6 +564,12 @@ function _deflt_clim(img::AbstractMatrix)
     Observable(CLim(saferound(gray(minval)), saferound(gray(maxval))))
 end
 
+# The method above began throwing an error for integers >1 in mid 2025
+# This restores the previous "clamping" behavior
+function _deflt_clim(img::AbstractMatrix{T}) where {T<:Integer}
+    Observable(CLim(0.0, 1.0))
+end
+
 function _deflt_clim(img::AbstractMatrix{T}) where {T<:AbstractRGB}
     minval = RGB(0.0,0.0,0.0)
     maxval = RGB(1.0,1.0,1.0)

--- a/src/ImageView.jl
+++ b/src/ImageView.jl
@@ -254,7 +254,7 @@ function imshow(frame::Union{Gtk4.GtkFrame,Gtk4.GtkAspectFrame}, canvas::GtkObse
     # such errors become easier to debug.
     if !supported_eltype(imgc[])
         !supported_eltype(imgsig[]) && error("got unsupported eltype $(eltype(imgsig[])) in creating slice")
-        error("got unsupported eltype $(eltype(imgc[])) in preparing the constrast")
+        error("got unsupported eltype $(eltype(imgc[])) in preparing the contrast")
     end
 
     roidict = imshow(frame, canvas, imgc, zr, anns)
@@ -590,7 +590,11 @@ default_axes(img::AxisArray) = axisnames(img)[[1,2]]
 
 function histsignals(enabled::Observable{Bool}, img::Observable, clim::Observable{CLim{T}}) where {T<:GrayLike}
     image, cl = img[], clim[]
-    Th = float(promote_type(T, eltype(image)))
+    hist_type = promote_type(T, eltype(image))
+    if hist_type == Any
+        error("got unsupported eltype Any in preparing the contrast")
+    end
+    Th = float(hist_type)
     function computehist(image, cl)
         smin, smax = valuespan(image)
         smin = float(min(smin, cl.min))

--- a/test/newtests.jl
+++ b/test/newtests.jl
@@ -126,7 +126,7 @@ end
     img = [OneChannelColor(0) OneChannelColor(1);
            OneChannelColor(2) OneChannelColor(3);
     ]
-    @test_throws ErrorException("got unsupported eltype Union{} in preparing the constrast") imshow(img, CLim(0, 1))
+    @test_throws ErrorException("got unsupported eltype Any in preparing the contrast") imshow(img, CLim(0, 1))
 
     struct MyChar <: AbstractChar
         c::Char


### PR DESCRIPTION
The ColorTypes function `gray` doesn't accept integers greater than 1 now, so handle integer matrices differently, maintaining the old behavior of clamping values greater than 1.

Also fix another broken test where `promote_type` returns `Any` instead of `Union{}`.